### PR TITLE
add sentry defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pino-sentry-transport",
-  "version": "1.3.1-alpha.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pino-sentry-transport",
-      "version": "1.3.1-alpha.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import type { Transform } from "node:stream";
 import {
   type NodeOptions,
   type SeverityLevel,
@@ -9,6 +8,7 @@ import {
 } from "@sentry/node";
 import type { Scope } from "@sentry/types";
 import get from "lodash.get";
+import type { Transform } from "node:stream";
 import build from "pino-abstract-transport";
 
 const pinoLevelToSentryLevel = (level: number): SeverityLevel => {
@@ -58,6 +58,11 @@ const defaultOptions: Partial<PinoSentryOptions> = {
   expectPinoConfig: false,
 };
 
+const defaultSentryOptions: NodeOptions = {
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+};
+
 export default async function (initSentryOptions: Partial<PinoSentryOptions>) {
   const pinoSentryOptions = { ...defaultOptions, ...initSentryOptions };
 
@@ -65,7 +70,7 @@ export default async function (initSentryOptions: Partial<PinoSentryOptions>) {
   const isInitialized = !!client;
 
   if (!isInitialized) {
-    init(pinoSentryOptions.sentry);
+    init({ ...defaultSentryOptions, ...pinoSentryOptions.sentry });
   }
 
   function enrichScope(scope: Scope, pinoEvent) {


### PR DESCRIPTION
Fixes #

## Description of the changes

Add sentry option defaults based on the SENTRY_DSN and NODE_ENV environment variables. 

Same as the winston sentry transport https://github.com/aandrewww/winston-transport-sentry-node/blob/b5dea93efb13ded366dde05956ba592b49b1031d/src/transport.ts#L144-L155