### PR TITLE
Fix incorrect log level in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const logger = pino({
 - **`withLogRecord`**: When set to `true`, sends the entire log record as context to Sentry. Be cautious of log records larger than 8KB, as Sentry will throw an error.
 - **`tags`**: An array specifying which fields from the log record should be added as tags in Sentry. Uses `lodash.get` to extract values.
 - **`context`**: An array specifying which fields from the log record should be added as context in Sentry. Also uses `lodash.get` for value extraction.
-- **`minLevel`**: The minimum log level required for a message to be sent to Sentry. Log levels follow Pino's conventions (e.g., 40 for 'error').
+- **`minLevel`**: The minimum log level required for a message to be sent to Sentry. Log levels follow Pino's conventions (e.g., 50 for 'error').
 - **`expectPinoConfig`**: If set to `true`, allows the transport to work with custom `messageKey` or `errorKey` settings in Pino.
 
 


### PR DESCRIPTION
Based on the code, it looks like level 50 is error:

https://github.com/tomer-yechiel/pino-sentry-transport/blob/main/src/index.ts#L18-L20