### PR TITLE
README: Reformat example to be compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ const logger = pino({
         options: {
             sentry: {
                 dsn: "https://<key>:<secret>@sentry.io/<project>",
-                // additional options for sentry
+                // additional options for Sentry
             },
-            withLogRecord: true, // default false - send the entire log record to sentry as a context.(FYI if its more then 8Kb Sentry will throw an error)
-            tags: ['level'], // sentry tags to add to the event, uses lodash.get to get the value from the log record
-            context: ['hostname'], // sentry context to add to the event, uses lodash.get to get the value from the log record,
-            minLevel: 40, // which level to send to sentry
-            expectPinoConfig: true, // default false - pass true if pino configured with custom messageKey or errorKey see below
+            // default false - send the entire log record to Sentry as a context.
+            // FYI: if it's more than 8Kb, Sentry will throw an error
+            withLogRecord: true,
+            // sentry tags to add to the event, uses `lodash.get` to get the value from the log record
+            tags: ['level'],
+            // sentry context to add to the event, uses `lodash.get` to get the value from the log record
+            context: ['hostname'],
+            // which level to send to Sentry
+            minLevel: 40,
+            // default false - pass true if pino is configured with custom messageKey or errorKey, see below
+            expectPinoConfig: true,
         }
     },
 });


### PR DESCRIPTION
## Description of the changes

Make the example more readable (shorter lines) by moving comments to their own lines.

This also makes easier to copy paste only values, omitting comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and formatting of inline comments in the logger configuration example, providing more detailed explanations and enhancing readability. No changes were made to configuration options or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->