### PR TITLE
refactor: replace deprecated lodash.get with own implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "pino-sentry-transport",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pino-sentry-transport",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "lodash.get": "^4.4.2",
         "pino-abstract-transport": "^1.2.0"
       },
       "devDependencies": {
@@ -18,7 +17,6 @@
         "@changesets/cli": "^2.29.5",
         "@sentry/node": "^9.38.0",
         "@sentry/types": "^9.38.0",
-        "@types/lodash.get": "^4.4.9",
         "@types/node": "^24.0.13",
         "@types/prompts": "^2.4.9",
         "cspell": "^9.1.5",
@@ -3060,21 +3058,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.185",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
-      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.get": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.9.tgz",
-      "integrity": "sha512-J5dvW98sxmGnamqf+/aLP87PYXyrha9xIgc2ZlHl6OHMFR2Ejdxep50QfU0abO1+CH6+ugx+8wEUN1toImAinA==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/mysql": {
       "version": "2.15.26",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
@@ -5031,11 +5014,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -9248,21 +9226,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.185",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
-      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
-      "dev": true
-    },
-    "@types/lodash.get": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.9.tgz",
-      "integrity": "sha512-J5dvW98sxmGnamqf+/aLP87PYXyrha9xIgc2ZlHl6OHMFR2Ejdxep50QfU0abO1+CH6+ugx+8wEUN1toImAinA==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/mysql": {
       "version": "2.15.26",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
@@ -10638,11 +10601,6 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@changesets/cli": "^2.29.5",
     "@sentry/node": "^9.38.0",
     "@sentry/types": "^9.38.0",
-    "@types/lodash.get": "^4.4.9",
     "@types/node": "^24.0.13",
     "@types/prompts": "^2.4.9",
     "cspell": "^9.1.5",
@@ -72,7 +71,6 @@
     "semver-regex": "3.1.4"
   },
   "dependencies": {
-    "lodash.get": "^4.4.2",
     "pino-abstract-transport": "^1.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export default async function (initSentryOptions: Partial<PinoSentryOptions>) {
           continue;
         }
 
-        context[c] = get(pinoEvent, value);
+        context[c] = value;
       }
       scope.setContext("pino-context", context);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import {
   type SeverityLevel,
 } from "@sentry/node";
 import type { Scope } from "@sentry/types";
-import get from "lodash.get";
 import build from "pino-abstract-transport";
 
 const pinoLevelToSentryLevel = (level: number): SeverityLevel => {
@@ -35,6 +34,13 @@ function deserializePinoError(pinoErr) {
   const newError = new Error(message);
   newError.stack = stack;
   return newError;
+}
+
+function get<T>(obj: T, path: string): unknown {
+  return path.split(".").reduce((acc, key) => {
+    if (acc == null) return undefined;
+    return (acc as Record<string, unknown>)[key];
+  }, obj);
 }
 
 interface PinoSentryOptions {
@@ -77,14 +83,30 @@ export default async function (initSentryOptions: Partial<PinoSentryOptions>) {
 
     if (pinoSentryOptions.tags?.length) {
       for (const tag of pinoSentryOptions.tags) {
-        scope.setTag(tag, get(pinoEvent, tag));
+        const value = get(pinoEvent, tag);
+
+        if (
+          typeof value !== "string" &&
+          typeof value !== "number" &&
+          typeof value !== "boolean"
+        ) {
+          continue;
+        }
+
+        scope.setTag(tag, value);
       }
     }
 
     if (pinoSentryOptions.context?.length) {
       const context = {};
       for (const c of pinoSentryOptions.context) {
-        context[c] = get(pinoEvent, c);
+        const value = get(pinoEvent, c);
+
+        if (typeof value !== "string") {
+          continue;
+        }
+
+        context[c] = get(pinoEvent, value);
       }
       scope.setContext("pino-context", context);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,25 @@ function deserializePinoError(pinoErr) {
   return newError;
 }
 
-function get<T>(obj: T, path: string): unknown {
-  return path.split(".").reduce((acc, key) => {
-    if (acc == null) return undefined;
-    return (acc as Record<string, unknown>)[key];
+function get<T>(obj: T, path: string | string[]): unknown {
+  // If the path is a string, handle both dot and bracket notation
+  const pathParts = Array.isArray(path)
+    ? path
+    : path.replace(/\[(\d+)\]/g, ".$1").split(".");
+
+  return pathParts.reduce((acc: unknown, key: string) => {
+    if (acc === null || acc === undefined) {
+      return undefined;
+    }
+
+    // Check if the current object has the key.
+    // This prevents errors on non-existent properties
+    if (typeof acc === "object" && acc.hasOwnProperty(key)) {
+      return acc[key];
+    }
+
+    // If the key doesn't exist, we return undefined
+    return undefined;
   }, obj);
 }
 


### PR DESCRIPTION
## Description of the changes

- Replaces deprecated lodash.get dependency
- Use much simpler own implementation
- Reduces package size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added new configuration options for controlling log record inclusion, tag/context lists, and initialization behavior.

- Bug Fixes
  - Safer handling of tags and context: only valid primitive values are applied; invalid or non-string context values are ignored to prevent errors and noise.

- Refactor
  - Replaced an external utility with a lightweight internal helper for nested value access; adjusted default options for more predictable behavior.

- Chores
  - Removed an external dependency and its type package, reducing install size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->